### PR TITLE
Fix launch script to respect user's PYTHONPATH

### DIFF
--- a/bin/python
+++ b/bin/python
@@ -67,7 +67,12 @@ find_package
 . ${ROOT_DIR}/bin/conda.sh && activate_conda_virtual_env "${ROOT_DIR}"
 
 # Then, launches a pyspark with given arguments
-PYTHONPATH="${ROOT_DIR}/python" \
+if [ -z "${PYTHONPATH}" ]; then
+  PYTHONPATH="${ROOT_DIR}/python"
+else
+  PYTHONPATH="${ROOT_DIR}/python:${PYTHONPATH}"
+fi
+PYTHONPATH=${PYTHONPATH} \
 PYTHONSTARTUP="${ROOT_DIR}/bin/.startup.py" \
   exec pyspark --jars=${PACKAGE} $(join_by " " ${SPARK_CONF[@]}) $(join_by " " ${ARGS[@]})
 


### PR DESCRIPTION
Users sometimes want to add their own libraries to `$PYTHONPATH`
to use them in the queries, but that variable is wholly overridden
with `${ROOT_DIR}/python` in bin/python. So it may be helpful
for users to respect the original value of `$PYTHONPATH`.